### PR TITLE
CMake: update minimum required version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1.3)
+cmake_minimum_required (VERSION 3.8)
 project (vortexfinder2)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
ParaView now requires that consumers use a minimum CMake version of 3.8. Update that here.